### PR TITLE
Compatibility with predis 1.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "php": ">=5.3",
-        "predis/predis": "~0.8"
+        "predis/predis": ">=0.8,<2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0",


### PR DESCRIPTION
Hello.
This small fix allows the package to be used with predis 1.x too.
Predis 1.0 mostly compatible with 0.8, and it is compatible for the rlock needs.
All tests pass as far as I can see.
